### PR TITLE
Add admin/structure/rng to menu

### DIFF
--- a/rng.links.menu.yml
+++ b/rng.links.menu.yml
@@ -1,24 +1,24 @@
 rng.registration_type.overview:
   title: 'Registration types'
-  parent: system.admin_structure
+  parent: rng.structure
   description: 'Manage registration types.'
   route_name: rng.registration_type.overview
 
 entity.registrant_type.collection:
   title: 'Registrant types'
-  parent: system.admin_structure
+  parent: rng.structure
   description: 'Manage registrant types.'
   route_name: entity.registrant_type.collection
 
 rng.config:
   title: 'RNG'
   parent: system.admin_config
-  description: 'Manage registration types.'
+  description: 'Manage global registration settings.'
   route_name: rng.config
 
 rng.event.overview:
   title: 'Event types'
-  parent: system.admin_structure
+  parent: rng.structure
   description: 'Manage which entity bundles are designated as events.'
   route_name: rng.event_type.overview
 
@@ -33,3 +33,9 @@ rng.config.plugin.condition:
   parent: rng.config
   description: 'Manage global settings for conditions defined by RNG.'
   route_name: rng.config.plugin.condition
+
+rng.structure:
+  title: 'RNG'
+  parent: system.admin_structure
+  description: 'Manage registration entity types.'
+  route_name: rng.structure

--- a/rng.routing.yml
+++ b/rng.routing.yml
@@ -197,6 +197,15 @@ rng.rng_event_type_rule.component.edit:
       component_id:
         type: 'rng_component_id'
 
+# RNG Structure overview
+rng.structure:
+  path: '/admin/structure/rng'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'RNG'
+  requirements:
+    _permission: 'access administration pages'
+
 # RNG Configuration
 rng.config:
   path: '/admin/config/rng'

--- a/src/Tests/RngEventTypeTest.php
+++ b/src/Tests/RngEventTypeTest.php
@@ -39,10 +39,15 @@ class RngEventTypeTest extends RngWebTestBase {
     $event_type->delete();
     $event_bundle->delete();
 
-    // Event types button on admin.
+    // Admin structure overview
     $this->drupalGet('admin/structure');
+    $this->assertLinkByHref(Url::fromRoute('rng.structure')->toString());
+    $this->assertRaw('Manage registration entity types.', 'RNG shows in administration structure.');
+
+    // Event types button on admin.
+    $this->drupalGet('admin/structure/rng');
     $this->assertLinkByHref(Url::fromRoute('rng.event_type.overview')->toString());
-    $this->assertRaw('Manage which entity bundles are designated as events.', 'Button shows in administration.');
+    $this->assertRaw('Manage which entity bundles are designated as events.', 'Event type overview link shows in RNG administration.');
 
     // No events.
     $this->assertEqual(0, count(EventType::loadMultiple()), 'There are no event type entities.');

--- a/src/Tests/RngRegistrationTypeTest.php
+++ b/src/Tests/RngRegistrationTypeTest.php
@@ -51,7 +51,7 @@ class RngRegistrationTypeTest extends RngSiteTestBase {
     $this->registration_type->delete();
 
     // Administration.
-    $this->drupalGet('admin/structure');
+    $this->drupalGet('admin/structure/rng');
     $this->assertLinkByHref(Url::fromRoute('rng.registration_type.overview')->toString());
 
     $this->drupalGet('admin/structure/rng/registration_types');


### PR DESCRIPTION
For a better overview of the RNG entity types, I suggest to add `admin/structure/rng` to the menu.

![Admin Structure RNG](http://share.undpaul.de/bilder/jh/RNG__Saxenkartell_2017-02-04_18-52-09--eslbf.png)