### PR TITLE
EventType::getIdentityTypeEntityFormMode() should return a form mode string

### DIFF
--- a/src/Entity/EventType.php
+++ b/src/Entity/EventType.php
@@ -211,7 +211,7 @@ class EventType extends ConfigEntityBase implements EventTypeInterface {
    */
   public function getIdentityTypeEntityFormMode($entity_type, $bundle) {
     $key = $this->getIdentityTypeKey($entity_type, $bundle);
-    return !empty($this->people_types[$key]['entity_form_mode']);
+    return !empty($this->people_types[$key]['entity_form_mode']) ? $this->people_types[$key]['entity_form_mode'] : 'default';
   }
 
   /**

--- a/tests/src/Kernel/RngEventTypeEntityTest.php
+++ b/tests/src/Kernel/RngEventTypeEntityTest.php
@@ -14,6 +14,41 @@ use Drupal\rng\Entity\EventType;
 class RngEventTypeEntityTest extends RngKernelTestBase {
 
   /**
+   * Tests getting a single identity type form mode.
+   *
+   * @covers ::getIdentityTypeEntityFormMode
+   */
+  public function testGetIdentityTypeEntityFormMode() {
+    $people_type = [
+      'entity_type' => $this->randomMachineName(),
+      'bundle' => $this->randomMachineName(),
+      'entity_form_mode' => $this->randomMachineName(),
+    ];
+    $values['people_types'][] = $people_type;
+    $event_type = $this->createEventTypeBase($values);
+
+    $result = $event_type->getIdentityTypeEntityFormMode($people_type['entity_type'], $people_type['bundle']);
+    $this->assertEquals($people_type['entity_form_mode'], $result);
+  }
+
+  /**
+   * Tests getting a single identity type form mode when no defaults set.
+   *
+   * @covers ::getIdentityTypeEntityFormMode
+   */
+  public function testGetIdentityTypeEntityFormModeNoDefaults() {
+    $people_type = [
+      'entity_type' => $this->randomMachineName(),
+      'bundle' => $this->randomMachineName(),
+    ];
+    $values['people_types'][] = $people_type;
+    $event_type = $this->createEventTypeBase($values);
+
+    $result = $event_type->getIdentityTypeEntityFormMode($people_type['entity_type'], $people_type['bundle']);
+    $this->assertEquals('default', $result);
+  }
+
+  /**
    * Test getting all identity type form modes.
    *
    * @covers ::getIdentityTypeEntityFormModes


### PR DESCRIPTION
On the event type form, when you select an alternative form mode for a person, it looks like the change is not saved, because when the form is reloaded the default form mode seems to be selected.

I have found that the bug is in `EventType::getIdentityTypeEntityFormMode()`. This returns a boolean, while it should return a string representing the selected form mode, according to `EntityTypeInterface::getIdentityTypeEntityFormMode()`.