### PR TITLE
Fix errors during config sync.

### DIFF
--- a/src/Entity/EventType.php
+++ b/src/Entity/EventType.php
@@ -353,6 +353,11 @@ class EventType extends ConfigEntityBase implements EventTypeInterface {
   public function postSave(EntityStorageInterface $storage, $update = TRUE) {
     parent::postSave($storage, $update);
 
+    // Do not change config when config sync is running.
+    if (\Drupal::isConfigSyncing()) {
+      return;
+    }
+
     // Create mode for the entity type.
     $mode_id = $this->entity_type . '.rng_event';
     if (!EntityFormMode::load($mode_id)) {


### PR DESCRIPTION
We were getting following errors during config sync:

`
The import failed due for the following reasons:
Deleted and replaced configuration entity
"field.field.node.event.rng_registration_type"
Unexpected error during import with operation create for
field.field.node.event.rng_registration_type: Attempt to create a
field rng_registration_type that does not exist on entity type node.
Deleted and replaced configuration entity
"core.entity_form_display.node.event.rng_event"
`

This PR fixes these errors