### PR TITLE
Redirect back to the event instead of frontpage

### DIFF
--- a/src/Form/RegistrationForm.php
+++ b/src/Form/RegistrationForm.php
@@ -218,7 +218,7 @@ class RegistrationForm extends ContentEntityForm {
       $form_state->setRedirectUrl($registration->toUrl());
     }
     else {
-      $form_state->setRedirect($event->toUrl);
+      $form_state->setRedirectUrl($event->toUrl);
     }
   }
 

--- a/src/Form/RegistrationForm.php
+++ b/src/Form/RegistrationForm.php
@@ -213,11 +213,12 @@ class RegistrationForm extends ContentEntityForm {
       $registrant->delete();
     }
 
+    $event = $registration->getEvent();
     if ($registration->access('view')) {
       $form_state->setRedirectUrl($registration->toUrl());
     }
     else {
-      $form_state->setRedirect('<front>');
+      $form_state->setRedirect($event->toUrl);
     }
   }
 

--- a/src/Form/RegistrationForm.php
+++ b/src/Form/RegistrationForm.php
@@ -218,7 +218,7 @@ class RegistrationForm extends ContentEntityForm {
       $form_state->setRedirectUrl($registration->toUrl());
     }
     else {
-      $form_state->setRedirectUrl($event->toUrl);
+      $form_state->setRedirectUrl($event->toUrl());
     }
   }
 


### PR DESCRIPTION
The event page is the better place after form submit to leave the user in page context.