### PR TITLE
168 - Renamed the default routing parameter

### DIFF
--- a/src/Access/EntityIsEventCheck.php
+++ b/src/Access/EntityIsEventCheck.php
@@ -36,7 +36,7 @@ class EntityIsEventCheck implements AccessInterface {
    * Checks that an entity is an event type.
    */
   public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
-    if ($event = $route->getDefault('event')) {
+    if ($event = $route->getDefault('rng_event_type')) {
       $event = $route_match->getParameter($event);
       if ($event instanceof EntityInterface) {
         $event_type = $this->eventManager->eventType($event->getEntityTypeId(), $event->bundle());

--- a/src/Access/EventRuleResetCheck.php
+++ b/src/Access/EventRuleResetCheck.php
@@ -38,7 +38,7 @@ class EventRuleResetCheck implements AccessInterface {
   public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account) {
     $access = AccessResult::neutral();
 
-    if ($event = $route->getDefault('event')) {
+    if ($event = $route->getDefault('rng_event_type')) {
       $event = $route_match->getParameter($event);
       if ($event instanceof EntityInterface) {
         $event_type = $this->eventManager->eventType($event->getEntityTypeId(), $event->bundle());

--- a/src/Access/RegistrationAddAccessCheck.php
+++ b/src/Access/RegistrationAddAccessCheck.php
@@ -36,7 +36,7 @@ class RegistrationAddAccessCheck implements AccessInterface {
    * Checks new registrations are permitted on an event.
    */
   public function access(Route $route, RouteMatchInterface $route_match, AccountInterface $account, RegistrationTypeInterface $registration_type = NULL) {
-    if ($event = $route->getDefault('event')) {
+    if ($event = $route->getDefault('rng_event_type')) {
       $context = ['event' => $route_match->getParameter($event)];
       $access_control_handler = $this->entityManager->getAccessControlHandler('registration');
       if ($registration_type) {

--- a/src/ContextProvider/RngEventRouteContext.php
+++ b/src/ContextProvider/RngEventRouteContext.php
@@ -80,7 +80,7 @@ class RngEventRouteContext implements ContextProviderInterface {
       return NULL;
     }
 
-    if ($event_param = $route->getDefault('event')) {
+    if ($event_param = $route->getDefault('rng_event_type')) {
       $event = $this->routeMatch->getParameter($event_param);
       return $event instanceof EntityInterface ? $event : NULL;
     }

--- a/src/Controller/RegistrationController.php
+++ b/src/Controller/RegistrationController.php
@@ -48,19 +48,19 @@ class RegistrationController extends ControllerBase implements ContainerInjectio
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The matched route.
    *
-   * @param string $event
+   * @param string $rng_event_type
    *   The parameter to find the event entity.
    *
    * @return array A registration form.
    */
-  public function RegistrationAddPage(RouteMatchInterface $route_match, $event) {
-    $event_entity = $route_match->getParameter($event);
+  public function RegistrationAddPage(RouteMatchInterface $route_match, $rng_event_type) {
+    $event_entity = $route_match->getParameter($rng_event_type);
     $render = [];
     $registration_types = $this->eventManager->getMeta($event_entity)->getRegistrationTypes();
     if (count($registration_types) == 1) {
       $registration_type = array_shift($registration_types);
-      return $this->redirect('rng.event.' . $event . '.register', [
-        $event => $event_entity->id(),
+      return $this->redirect('rng.event.' . $rng_event_type . '.register', [
+        $rng_event_type => $event_entity->id(),
         'registration_type' => $registration_type->id(),
       ]);
     }
@@ -104,7 +104,7 @@ class RegistrationController extends ControllerBase implements ContainerInjectio
    * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
    *   The matched route.
    *
-   * @param string $event
+   * @param string $rng_event_type
    *   The parameter to find the event entity.
    *
    * @param \Drupal\rng\RegistrationTypeInterface $registration_type
@@ -112,8 +112,8 @@ class RegistrationController extends ControllerBase implements ContainerInjectio
    *
    * @return array A registration form.
    */
-  public function RegistrationAdd(RouteMatchInterface $route_match, $event, RegistrationTypeInterface $registration_type) {
-    $event_entity = $route_match->getParameter($event);
+  public function RegistrationAdd(RouteMatchInterface $route_match, $rng_event_type, RegistrationTypeInterface $registration_type) {
+    $event_entity = $route_match->getParameter($rng_event_type);
     $registration = Registration::create([
       'type' => $registration_type->id(),
     ]);

--- a/src/Plugin/Menu/LocalAction/ResetAccessRules.php
+++ b/src/Plugin/Menu/LocalAction/ResetAccessRules.php
@@ -72,7 +72,7 @@ class ResetAccessRules extends LocalActionDefault {
    */
   public function getTitle() {
     $route = $this->routeProvider->getRouteByName($this->getRouteName());
-    $param = $route->getDefault('event');
+    $param = $route->getDefault('rng_event_type');
 
     if ($event = $this->currentRoute->getParameter($param)) {
       if ($this->eventManager->getMeta($event)->isDefaultRules('rng_event.register')) {

--- a/src/Routing/Enhancer/RngRouteEnhancer.php
+++ b/src/Routing/Enhancer/RngRouteEnhancer.php
@@ -15,14 +15,14 @@ class RngRouteEnhancer implements RouteEnhancerInterface {
    * {@inheritdoc}
    */
   public function applies(Route $route) {
-    return $route->hasRequirement('_entity_is_event') && $route->hasDefault('event');
+    return $route->hasRequirement('_entity_is_event') && $route->hasDefault('rng_event_type');
   }
 
   /**
    * {@inheritdoc}
    */
   public function enhance(array $defaults, Request $request) {
-    $event_entity_type = $defaults['event'];
+    $event_entity_type = $defaults['rng_event_type'];
 
     if (isset($defaults[$event_entity_type])) {
       $rng_event = $defaults[$event_entity_type];

--- a/src/Routing/RouteSubscriber.php
+++ b/src/Routing/RouteSubscriber.php
@@ -69,7 +69,7 @@ class RouteSubscriber extends RouteSubscriberBase {
             '_form' => '\Drupal\rng\Form\EventSettingsForm',
             '_title' => 'Manage event',
             // Tell controller which parameter the event entity is stored.
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements,
           $options
@@ -82,7 +82,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           [
             '_form' => '\Drupal\rng\Form\EventAccessForm',
             '_title' => 'Access',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ],
           $manage_requirements,
           $options
@@ -95,7 +95,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_form' => '\Drupal\rng\Form\EventAccessResetForm',
             '_title' => 'Reset access to default',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements + [
             '_event_rule_reset' => 'TRUE',
@@ -110,7 +110,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_form' => '\Drupal\rng\Form\MessageListForm',
             '_title' => 'Messages',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements,
           $options
@@ -123,7 +123,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_form' => '\Drupal\rng\Form\MessageActionForm',
             '_title' => 'Add message',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements,
           $options
@@ -136,7 +136,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_controller' => '\Drupal\rng\Controller\GroupController::listing',
             '_title' => 'Groups',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements,
           $options
@@ -149,7 +149,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_controller' => '\Drupal\rng\Controller\GroupController::GroupAdd',
             '_title' => 'Add group',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           $manage_requirements,
           $options
@@ -162,7 +162,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_controller' => '\Drupal\rng\Controller\RegistrationController::RegistrationAddPage',
             '_title' => 'Register',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           array(
             '_registration_add_access' => 'TRUE',
@@ -178,7 +178,7 @@ class RouteSubscriber extends RouteSubscriberBase {
           array(
             '_controller' => '\Drupal\rng\Controller\RegistrationController::RegistrationAdd',
             '_title_callback' => '\Drupal\rng\Controller\RegistrationController::addPageTitle',
-            'event' => $entity_type,
+            'rng_event_type' => $entity_type,
           ),
           array(
             '_registration_add_access' => 'TRUE',


### PR DESCRIPTION
References #168


Renamed the default routing parameter "event" to "rng_event"type" to prevent possible clashes with custom entity routes which use "event" as a routing parameter.