### PR TITLE
Must add Prefix to dependencies

### DIFF
--- a/rng.info.yml
+++ b/rng.info.yml
@@ -4,7 +4,7 @@ description: 'Provides ability to create and manage events and registrations.'
 package: RNG
 core: 8.x
 dependencies:
-  - system (>=8.1)
-  - dynamic_entity_reference
-  - courier
-  - unlimited_number (>=8.x-1.0-beta2)
+  - drupal:system (>=8.1)
+  - dynamic_entity_reference:dynamic_entity_reference
+  - courier:courier
+  - unlimited_number:unlimited_number (>=8.x-1.0-beta2)

--- a/rng_debug/rng_debug.info.yml
+++ b/rng_debug/rng_debug.info.yml
@@ -4,4 +4,4 @@ description: 'Debug event settings.'
 package: RNG
 core: 8.x
 dependencies:
-  - rng
+  - rng:rng

--- a/rng_views/rng_views.info.yml
+++ b/rng_views/rng_views.info.yml
@@ -4,7 +4,7 @@ description: 'Improved Views integration for RNG.'
 package: RNG
 core: 8.x
 dependencies:
-  - rng
-  - views
-  - veoa
-  - views_advanced_routing
+  - rng:rng
+  - drupal:views
+  - veoa:veoa
+  - views_advanced_routing:views_advanced_routing


### PR DESCRIPTION
All dependencies must be prefixed by project name, So please <a href="https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file">apply new {project}:{module} format for dependencies in info.yml file</a>
<p>It is supported since 8.0 and 7.40 Change Record: <a href="https://www.drupal.org/node/2299747">Project namespaces can now be added for module dependencies</a>, and is now a Best Practice <a href="https://www.drupal.org/project/drupal/issues/2798891">Define project dependencies in core module .info files</a>).</p><p>
It is useful for DrupalCi to download the right dependencies and Installation profiles to work well. So sooner is better.
So, here is the PR. Please review.
I also added missing empty last line.
Hope this helps.</p>