### PR TITLE
Fix Issue #170

### DIFF
--- a/src/Element/Registrants.php
+++ b/src/Element/Registrants.php
@@ -643,6 +643,12 @@ class Registrants extends FormElement {
   public static function validateRegisterable(&$element, FormStateInterface $form_state, &$complete_form) {
     $utility = new RegistrantsElement($element, $form_state);
 
+    // Add existing registrants to whitelist.
+    foreach ($complete_form['registrants_before']['#value'] as $existing_registrant) {
+      $identity = $existing_registrant->getIdentity();
+      $utility->addWhitelistExisting($identity);
+    }
+
     /** @var \Drupal\rng\RegistrantInterface[] $registrants */
     $registrants = $element['#value'];
     $whitelisted = $utility->getWhitelistExisting();


### PR DESCRIPTION
This should fix the bug preventing existing registrations from being updated.
It looks like there was a whitelist functionality in place that should have prevented the false-positive in the validation function. However, the existing users were never being added to the whitelist on the Edit form, so it prevented this from working as expected. 